### PR TITLE
Move serialize method to ConstantPool - avoids feature envy

### DIFF
--- a/compiler/ballerina-backend-llvm/src/main/java/org/ballerinalang/compiler/backend/llvm/NativeGen.java
+++ b/compiler/ballerina-backend-llvm/src/main/java/org/ballerinalang/compiler/backend/llvm/NativeGen.java
@@ -203,8 +203,8 @@ public class NativeGen {
     }
 
     private static byte[] getBinaryForm(BIRPackage bir) {
-        BIRBinaryWriter binaryWriter = new BIRBinaryWriter();
-        return binaryWriter.write(bir);
+        BIRBinaryWriter binaryWriter = new BIRBinaryWriter(bir);
+        return binaryWriter.serialize();
     }
 
     private static void genExecutable(Path objectFilePath, String execFilename) {

--- a/compiler/ballerina-lang/spotbugs-exclude.xml
+++ b/compiler/ballerina-lang/spotbugs-exclude.xml
@@ -85,4 +85,8 @@
     <Match>
         <Class name="org.wso2.ballerinalang.compiler.packaging.converters.URIConverter"/>
     </Match>
+    <Match>
+        <Class name="org.wso2.ballerinalang.compiler.bir.writer.ConstantPool"/>
+        <Bug pattern="BC_UNCONFIRMED_CAST_OF_RETURN_VALUE"/>
+    </Match>
 </FindBugsFilter>


### PR DESCRIPTION
## Purpose
I have done this so I can use ConstantPool class in unit testing.